### PR TITLE
Set images key

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ var options = [
 	{
 		pattern: 'projects/**/*.md',
 	},
+
+	// add all images to its matching project with a different metadata key
+	{
+		pattern: 'projects/**/*.md',
+        imagesDirectory: 'maps',
+        imagesKey: 'maps',
+	},
 ]
 ```
 
@@ -118,6 +125,7 @@ var options = [
 | pattern | `**/*.md` | pattern for files to scan images for |
 | authorizedExts | jpg, jpeg, svg, png, gif, JPG, JPEG, SVG, PNG, GIF | allowed image extensions |
 | imagesDirectory | `images` | directory inside the pattern to look for images to add |
+| imagesKey | `images` | name of metadata key to hold images collection |
 
 ## License
 MIT

--- a/src/index.js
+++ b/src/index.js
@@ -52,18 +52,18 @@ function addImagesToFiles(files, metalsmith, done, options) {
 
     var imagesPath = path.join(metalsmith.source(), path.dirname(file), options.imagesDirectory);
     var dirFiles = fs.readdirSync(imagesPath);
-    files[file].images = files[file].images || [];
+    files[file][options.imagesKey] = files[file][options.imagesKey] || [];
 
     // add files as images metadata
     _.each(dirFiles, function(dirFile) {
       // check extension and remove thumbnails
       if (isAuthorizedFile(dirFile, options.authorizedExts)) {
         var imagePath = path.join(files[file].path.dir, options.imagesDirectory, dirFile);
-        files[file].images.push(imagePath);
+        files[file][options.imagesKey].push(imagePath);
       }
     });
 
-    files[file].images = _.uniq(files[file].images);
+    files[file][options.imagesKey] = _.uniq(files[file][options.imagesKey]);
   });
 };
 
@@ -81,6 +81,7 @@ function normalizeOptions(options) {
     authorizedExts: ['jpg', 'jpeg', 'svg', 'png', 'gif', 'JPG', 'JPEG', 'SVG', 'PNG', 'GIF'],
     pattern: '**/*.md',
     imagesDirectory: 'images',
+    imagesKey: 'images',
   };
 
   return _.extend(defaultOptions, options);

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,7 @@ describe('Metalsmith-images', function() {
             authorizedExts: ['jpg', 'jpeg', 'svg', 'png', 'gif', 'JPG', 'JPEG', 'SVG', 'PNG', 'GIF'],
             pattern: '**/*.md',
             imagesDirectory: 'images',
+            imagesKey: 'images',
           });
       });
 
@@ -67,7 +68,8 @@ describe('Metalsmith-images', function() {
         expect(updatedOptions).to.eql({
           authorizedExts: ['jpg', 'jpeg', 'svg', 'png', 'gif', 'JPG', 'JPEG', 'SVG', 'PNG', 'GIF'],
           pattern: 'test/*.md',
-          imagesDirectory: 'images'
+          imagesDirectory: 'images',
+          imagesKey: 'images',
         });
       })
 
@@ -77,7 +79,8 @@ describe('Metalsmith-images', function() {
         expect(updatedOptions).to.eql({
           authorizedExts: ['tiff'],
           pattern: '**/*.md',
-          imagesDirectory: 'images'
+          imagesDirectory: 'images',
+          imagesKey: 'images',
         })
       })
 
@@ -87,7 +90,8 @@ describe('Metalsmith-images', function() {
         expect(updatedOptions).to.eql({
           authorizedExts: ['jpg', 'jpeg', 'svg', 'png', 'gif', 'JPG', 'JPEG', 'SVG', 'PNG', 'GIF'],
           pattern: '**/*.md',
-          imagesDirectory: 'imgs'
+          imagesDirectory: 'imgs',
+          imagesKey: 'images',
         })
       })
     });

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,12 @@ var _ = require('lodash'),
     getMatchingFiles = images.getMatchingFiles,
     isAuthorizedFile = images.isAuthorizedFile;
 
-function getFilesWithImages(files) {
+function getFilesWithImages(files, imagesKey) {
+  imagesKey = imagesKey || 'images';
   return _.chain(files)
     .map(function(file, index, files) {
       var obj = {}
-      obj[index] = file.images;
+      obj[index] = file[imagesKey];
       return obj
     })
     .filter(function(file, index, files) {
@@ -130,6 +131,25 @@ describe('Metalsmith-images', function() {
           if (err) return done(err);
           // console.log('FILES', files);
           var filesWithImages = getFilesWithImages(files);
+
+          expect(filesWithImages).to.deep.include.members([
+            { 'one/one.md': [ 'one/images/Toadle.gif', 'one/images/Toadle.png' ] },
+            { 'three/three.md': [ 'three/images/listen.png', 'three/images/now.png' ] },
+            { 'two/two.md': [ 'two/images/Toad.png' ] }
+          ])
+
+          done();
+        });
+    });
+
+    it('should add images to specified metadata key of matching files', function(done){
+      var metalsmith = Metalsmith('test/fixtures/pattern');
+      metalsmith
+        .use(images({ pattern: '**/*.md', imagesKey: 'maps' }))
+        .build(function(err, files){
+          if (err) return done(err);
+          // console.log('FILES', files);
+          var filesWithImages = getFilesWithImages(files, 'maps');
 
           expect(filesWithImages).to.deep.include.members([
             { 'one/one.md': [ 'one/images/Toadle.gif', 'one/images/Toadle.png' ] },


### PR DESCRIPTION
Allows setting the metadata key the image collection is added to.
### Use Case

It's possible for a single project to have multiple _groups_ of images, instead of a single collection of images. This pull request enables setting the metadata key (default `images`) so it's possible to reference groups of images by different bucket references.

For example, on a single project, let's imagine we have:
- `project/screenshots`
- `project/flow-diagrams`
- `project/ads`

With the following configuration we can differentiate these on the project template:

``` javascript
var options = [
    // for project screenshots, displayed as an image carousel
    // (accessible via `file.images` as normal)
    {
        pattern: 'project/*.',
        imagesDirectory: 'screenshots',
    },

    // for flow-diagrams, displayed as a list of links only
    {
        pattern: 'project/*.',
        imagesDirectory: 'flow-diagrams',
        imagesKey: 'flow',
    },

    // randomize the collection and inline display the advertisements!
    {
        pattern: 'projects/**/*.md',
        imagesDirectory: 'ads',
        imagesKey: 'ads',
    },
]
```
### Changelog
- Adds `imagesKey` option
- Adds a test for successfully setting the specified key name
- Updates README.md to document the new option
