### PR TITLE
Correct options array handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ function plugin(options) {
 return function innerFunction(files, metalsmith, done) {
   setImmediate(done);
 
-  // sane deafult
+  // sane default
   var optionsArray = [];
 
   if (_.isArray(options)) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,20 +23,22 @@ module.exports.getMatchingFiles = getMatchingFiles;
  */
 function plugin(options) {
 
-  return function innerFunction(files, metalsmith, done) {
-    setImmediate(done);
+return function innerFunction(files, metalsmith, done) {
+  setImmediate(done);
 
-    // one options object
-    if (_.isObject(options)) {
-        addImagesToFiles(files, metalsmith, done, options);
-    }
+  // sane deafult
+  var optionsArray = [];
 
+  if (_.isArray(options)) {
     // multiple options objects
-    if (_.isArray(options)) {
-        _.each(options, function(optionsItem) {
-          addImagesToFiles(files, metalsmith, done, optionsItem);
-        })
-    }
+    optionsArray = options;
+  } else if (_.isObject(options)) {
+    // one options object
+    optionsArray = [options];
+  }
+  _.each(optionsArray, function(optionsItem) {
+    addImagesToFiles(files, metalsmith, done, optionsItem);
+  })
 }
 
 function addImagesToFiles(files, metalsmith, done, options) {

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ describe('Metalsmith-images', function() {
           if (err) return done(err);
 
           var filesWithImages = getFilesWithImages(files)
-          // console.log(filesWithImages);
+
           expect(filesWithImages).to.deep.include.members([
             { 'one/one.md': [ 'one/images/Toadle.gif', 'one/images/Toadle.png' ] },
             { 'projects/hello/world.md': [ 'projects/hello/images/Toadle.gif', 'projects/hello/images/Toadle.png' ] }

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ describe('Metalsmith-images', function() {
           if (err) return done(err);
 
           var filesWithImages = getFilesWithImages(files)
-          console.log(filesWithImages);
+          // console.log(filesWithImages);
           expect(filesWithImages).to.deep.include.members([
             { 'one/one.md': [ 'one/images/Toadle.gif', 'one/images/Toadle.png' ] },
             { 'projects/hello/world.md': [ 'projects/hello/images/Toadle.gif', 'projects/hello/images/Toadle.png' ] }


### PR DESCRIPTION
Correct how an array of options is handled.
### Overview

When passing an array of options, the array is mangled into an associative array. As such, the individual settings are lost and project images are lost.

Part of the issue is that apparently `_.isObject()` returns `true` if the options array is an array. Go figure.
### Changelog
- Remove console output during tests
- Refactor array option handling
