### PR TITLE
Use sync version of fs.exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,24 +52,23 @@ function addImagesToFiles(files, metalsmith, done, options) {
     if (_.isUndefined(files[file])) return true;
 
     var imagesPath = path.join(metalsmith.source(), path.dirname(file), options.imagesDirectory);
-    fs.exists(imagesPath, function(exist) {
-      // no access, skip the path
-      if (!exist) return;
+    var exist = fs.existsSync(imagesPath);
+    // no access, skip the path
+    if (!exist) return;
 
-      var dirFiles = fs.readdirSync(imagesPath);
-      files[file][options.imagesKey] = files[file][options.imagesKey] || [];
+    var dirFiles = fs.readdirSync(imagesPath);
+    files[file][options.imagesKey] = files[file][options.imagesKey] || [];
 
-      // add files as images metadata
-      _.each(dirFiles, function(dirFile) {
-        // check extension and remove thumbnails
-        if (isAuthorizedFile(dirFile, options.authorizedExts)) {
-          var imagePath = path.join(files[file].path.dir, options.imagesDirectory, dirFile);
-          files[file][options.imagesKey].push(imagePath);
-        }
-      });
-
-      files[file][options.imagesKey] = _.uniq(files[file][options.imagesKey]);
+    // add files as images metadata
+    _.each(dirFiles, function(dirFile) {
+      // check extension and remove thumbnails
+      if (isAuthorizedFile(dirFile, options.authorizedExts)) {
+        var imagePath = path.join(files[file].path.dir, options.imagesDirectory, dirFile);
+        files[file][options.imagesKey].push(imagePath);
+      }
     });
+
+    files[file][options.imagesKey] = _.uniq(files[file][options.imagesKey]);
   });
 };
 


### PR DESCRIPTION
I just used the sync version of fs.exists to avoid async operations after "done" was called.