### PR TITLE
Added ability to pass a function for the image directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function addImagesToFiles(files, metalsmith, done, options) {
 
     var imagesDirectory = options.imagesDirectory;
     if (typeof imagesDirectory === "function") {
-    	imagesDirectory = imagesDirectory(file);
+    	imagesDirectory = imagesDirectory(file, files[file]);
     }
 
 


### PR DESCRIPTION
Main change of this PR is the added ability to pass a function for the image directory. This gives the ability to change the search folder based on the input.

The accepted function accepts the file name and metalsmith file object.

My specific use case was having the images in a folder named as project name.
```
projects/
|-- project1.md
|-- project1/
|    |-- image1.jpg
|    |-- image2.jpg
|    |-- image3.jpg
|-- project2.md
|-- project2/
|    |-- image1.jpg
|    |-- image2.jpg
|    |-- image3.jpg
```

This is the example configuration

```js
{
	pattern: 'projects/*.md',
	imagesDirectory: f =>
		f
			.split('.').slice(0, -1).join('.') // remove file extension
			.split('/').slice(1).join('/'), // remove first directory (projects)
}
```

Other changes:
- added some debugging logs
- removed edit of file path object. Since the purpose of the plugin is to list images the change of the path was unexpected behavior.